### PR TITLE
modify query for searching for friends

### DIFF
--- a/src/cltl/brain/ontologies/BASIC-REPOSITORY-CONFIG-GRAPHDB.ttl
+++ b/src/cltl/brain/ontologies/BASIC-REPOSITORY-CONFIG-GRAPHDB.ttl
@@ -1,0 +1,41 @@
+#
+# RDF4J configuration template for a GraphDB Free repository
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix owlim: <http://www.ontotext.com/trree/owlim#>.
+
+[] a rep:Repository ;
+    rep:repositoryID "sandbox" ;
+    rdfs:label "DB for experiments" ;
+    rep:repositoryImpl [
+        rep:repositoryType "graphdb:FreeSailRepository" ;
+        sr:sailImpl [
+            sail:sailType "graphdb:FreeSail" ;
+            
+            owlim:base-URL "http://example.org/owlim#" ;
+            owlim:defaultNS "" ;
+            owlim:entity-index-size "10000000" ;
+            owlim:entity-id-size  "32" ;
+            owlim:imports "" ;
+        	owlim:repository-type "file-repository" ;
+            owlim:ruleset "owl2-rl-optimized" ;
+            owlim:storage-folder "storage" ;
+ 
+            owlim:enable-context-index "true" ;
+
+            owlim:enablePredicateList "true" ;
+
+            owlim:in-memory-literal-properties "true" ;
+            owlim:enable-literal-index "true" ;
+
+            owlim:check-for-inconsistencies "true" ;
+            owlim:disable-sameAs  "false" ;
+            owlim:query-timeout  "0" ;
+            owlim:query-limit-results  "0" ;
+            owlim:throw-QueryEvaluationException-on-timeout "false" ;
+            owlim:read-only "false" ;
+        ]
+    ].

--- a/src/cltl/brain/queries/content_exploration/all_negation_conflicts.rq
+++ b/src/cltl/brain/queries/content_exploration/all_negation_conflicts.rq
@@ -4,6 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX graspf: <http://groundedannotationframework.org/grasp/factuality#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX sem: <http://semanticweb.cs.vu.nl/2009/11/sem/>
+prefix leolaniFriends: <http://cltl.nl/leolani/friends/>
 
 SELECT ?g ?datePos ?authorPos ?dateNeg ?authorNeg
 
@@ -31,8 +32,8 @@ WHERE {
     ?mNeg grasp:wasAttributedTo ?authorNeg .
 
 
-    FILTER (STRSTARTS(STR(?authorPos), "http://cltl.nl/leolani/friends/")
-            && STRSTARTS(STR(?authorNeg), "http://cltl.nl/leolani/friends/")
+    FILTER (STRSTARTS(STR(?authorPos), STR(leolaniFriends:))
+            && STRSTARTS(STR(?authorNeg), STR(leolaniFriends:))
     ) .
 
 }

--- a/src/cltl/brain/queries/content_exploration/my_friends.rq
+++ b/src/cltl/brain/queries/content_exploration/my_friends.rq
@@ -5,4 +5,6 @@ PREFIX n2mu: <http://cltl.nl/leolani/n2mu/>
 select distinct ?friend where {
     ?friend rdf:type sem:Actor .
     ?friend rdf:type n2mu:person .
+
+    FILTER(STRSTARTS(STR(?friend), STR(leolaniFriends:)))
 }

--- a/src/cltl/brain/queries/trust/conflicts_by.rq
+++ b/src/cltl/brain/queries/trust/conflicts_by.rq
@@ -4,6 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX graspf: <http://groundedannotationframework.org/grasp/factuality#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX sem: <http://semanticweb.cs.vu.nl/2009/11/sem/>
+prefix leolaniFriends: <http://cltl.nl/leolani/friends/>
 
 SELECT ?g ?datePos ?authorPos ?dateNeg ?authorNeg
 
@@ -34,8 +35,8 @@ WHERE {
 
     FILTER (?authorPos = <%s> || ?authorNeg = <%s> ) .
 
-    FILTER (STRSTARTS(STR(?authorPos), "http://cltl.nl/leolani/friends/")
-            && STRSTARTS(STR(?authorNeg), "http://cltl.nl/leolani/friends/")
+    FILTER (STRSTARTS(STR(?authorPos), STR(leolaniFriends:))
+            && STRSTARTS(STR(?authorNeg), STR(leolaniFriends:))
     ) .
 
 }


### PR DESCRIPTION
The bug comes because each 'friend' is linked to an 'person' in the world. This difference allows us to talk about people we have not met. 

The query has been updated to return only one entity.