### PR TITLE
Update rdf_builder.py

### DIFF
--- a/src/cltl/brain/infrastructure/rdf_builder.py
+++ b/src/cltl/brain/infrastructure/rdf_builder.py
@@ -36,8 +36,8 @@ class RdfBuilder(object):
 
         """
         self.dataset = Dataset()
-        self._bind_namespaces(self.ontology_details)
-        self.define_named_graphs()
+      #  self._bind_namespaces(self.ontology_details)
+      #  self.define_named_graphs()
 
     def _define_namespaces(self):
         """


### PR DESCRIPTION
fresh_local_memory not only creates a new Dataset() but also calls:

       # self._bind_namespaces(self.ontology_details)
       # self.define_named_graphs()

self._ontology_details is not defined and crashes here. When commenting out both calls it all works.